### PR TITLE
容量コード赤枠表示、缶タブGridViewのステータス表示(色)

### DIFF
--- a/NpCommon/Database/Sql/NpMain/ProductNoMaster.cs
+++ b/NpCommon/Database/Sql/NpMain/ProductNoMaster.cs
@@ -63,8 +63,15 @@ namespace NipponPaint.NpCommon.Database.Sql.NpMain
         }
         #endregion
 
-
-        
+        #region 品名コードによるレコード件数取得
+        public static string GetCountByProductNo()
+        {
+            var sql = new StringBuilder();
+            sql.Append($"select COUNT(Product_No) as Product_No_Count FROM ProductNo_Master ");
+            sql.Append($"where Product_No = @ProductNo");
+            return sql.ToString();
+        }
+        #endregion
 
         #region 更新系
     }

--- a/NpCommon/Settings/GridViewSetting.cs
+++ b/NpCommon/Settings/GridViewSetting.cs
@@ -26,6 +26,7 @@ namespace NipponPaint.NpCommon.Settings
             String,
             DateTime,
             Checkbox,
+            Blank,
         }
         /// <summary>
         /// データの種類
@@ -80,6 +81,8 @@ namespace NipponPaint.NpCommon.Settings
                 {
                     case ColumnModeType.String:
                         return $"TRIM(TRIM('　' FROM {ColumnName})) AS {DisplayName} ";
+                    case ColumnModeType.Blank:
+                        return $"'' AS {DisplayName} ";
                     default:
                         return $"{ColumnName} AS {DisplayName} ";
                 }

--- a/OrderManager/FrmMain.Designer.cs
+++ b/OrderManager/FrmMain.Designer.cs
@@ -230,6 +230,7 @@ namespace NipponPaint.OrderManager
             this.ToolStripMenuItemCCMSimulator = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStripMenuItemLabelSelection = new System.Windows.Forms.ToolStripMenuItem();
             this.ヘルプHToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.BorderHgVolumeCode = new NipponPaint.NpCommon.FormControls.PanelBorder();
             this.tabOrder.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.GvOrder)).BeginInit();
             this.contextMenuStrip.SuspendLayout();
@@ -495,6 +496,7 @@ namespace NipponPaint.OrderManager
             this.tabDetail1.Controls.Add(this.BorderHgTintingDirection);
             this.tabDetail1.Controls.Add(this.BorderHgSamplePlates);
             this.tabDetail1.Controls.Add(this.BorderHgNote);
+            this.tabDetail1.Controls.Add(this.BorderHgVolumeCode);
             this.tabDetail1.Font = new System.Drawing.Font("メイリオ", 7F);
             this.tabDetail1.Location = new System.Drawing.Point(4, 32);
             this.tabDetail1.Name = "tabDetail1";
@@ -4051,6 +4053,16 @@ namespace NipponPaint.OrderManager
             this.ヘルプHToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
             this.ヘルプHToolStripMenuItem.Text = "ヘルプ(&H)";
             // 
+            // BorderHgVolumeCode
+            // 
+            this.BorderHgVolumeCode.BackColor = System.Drawing.Color.Transparent;
+            this.BorderHgVolumeCode.BorderColor = System.Drawing.Color.Red;
+            this.BorderHgVolumeCode.Location = new System.Drawing.Point(0, 206);
+            this.BorderHgVolumeCode.Margin = new System.Windows.Forms.Padding(2, 5, 2, 5);
+            this.BorderHgVolumeCode.Name = "BorderHgVolumeCode";
+            this.BorderHgVolumeCode.Size = new System.Drawing.Size(299, 36);
+            this.BorderHgVolumeCode.TabIndex = 100;
+            // 
             // FrmMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 23F);
@@ -4321,6 +4333,7 @@ namespace NipponPaint.OrderManager
         private System.Windows.Forms.Button BtnPrint;
         private System.Windows.Forms.Button BtnRemanufacturedCan;
         private System.Windows.Forms.Button BtnPrintTag;
+        private NpCommon.FormControls.PanelBorder BorderHgVolumeCode;
     }
 }
 

--- a/OrderManager/FrmMain.cs
+++ b/OrderManager/FrmMain.cs
@@ -54,6 +54,7 @@ namespace NipponPaint.OrderManager
 
 
         private const int COLUMN_STATUS = 0;
+        private const int COLUMN_STATUS_COLOR = 1;
         //private int COLUMN_PRODUCT_NAME = 0;
         //private int COLUMN_COLOR_NAME = 0;
         private const int COLUMN_DELIVERY_CODE = 2;
@@ -108,7 +109,8 @@ namespace NipponPaint.OrderManager
         };
         private List<GridViewSetting> ViewSettingsOrderNumbers = new List<GridViewSetting>()
         {
-            { new GridViewSetting() { ColumnType = GridViewSetting.ColumnModeType.Numeric, ColumnName = "Status", DisplayName = "Status", Visible = true, Width = 35, alignment = DataGridViewContentAlignment.MiddleCenter } },
+            { new GridViewSetting() { ColumnType = GridViewSetting.ColumnModeType.Numeric, ColumnName = "Status", DisplayName = "Status", Visible = false, Width = 35, alignment = DataGridViewContentAlignment.MiddleCenter } },
+            { new GridViewSetting() { ColumnType = GridViewSetting.ColumnModeType.Blank, ColumnName = "StatusColor", DisplayName = "StatusColor", Visible = true, Width = 35, alignment = DataGridViewContentAlignment.MiddleCenter } },
             { new GridViewSetting() { ColumnType = GridViewSetting.ColumnModeType.String, ColumnName = "Product_Code", DisplayName = "製品コード", Visible = true, Width = 110, alignment = DataGridViewContentAlignment.MiddleCenter } },
             { new GridViewSetting() { ColumnType = GridViewSetting.ColumnModeType.Numeric, ColumnName = "Number_of_cans", DisplayName = "缶数", Visible = true, Width = 95, alignment = DataGridViewContentAlignment.MiddleRight } },
             { new GridViewSetting() { ColumnType = GridViewSetting.ColumnModeType.String, ColumnName = "Order_Number", DisplayName = "注文番号", Visible = true, Width = 175, alignment = DataGridViewContentAlignment.MiddleCenter } },
@@ -310,7 +312,7 @@ namespace NipponPaint.OrderManager
         {
             try
             {
-                DataGridViewFormatting((DataGridView)sender);
+                GvOrderNumberFormatting((DataGridView)sender);
                 PutLog(Sentence.Messages.PreviewData);
             }
             catch (Exception ex)
@@ -1114,6 +1116,23 @@ namespace NipponPaint.OrderManager
                                 BorderHgNote.Visible = false;
                             }
                         }
+                        //容量コードのLabelTextBoxコントロールに設定された値を取得してProductNo_Masterに存在するか確認する
+                        string productNo = HgProductNo.Value.Trim();
+                        // 行取得のSQLを作成
+                        parameters = new List<ParameterItem>()
+                        {
+                            new ParameterItem("ProductNo", productNo),
+                        };
+                        rec = db.Select(Sql.NpMain.ProductNoMaster.GetCountByProductNo(), parameters);
+                        result = int.TryParse(rec.Rows[0]["Product_No_Count"].ToString(), out intResult);
+                        if (result)
+                        {
+                            BorderHgVolumeCode.Visible = 0 < intResult;
+                        }
+                        else
+                        {
+                            BorderHgVolumeCode.Visible = false;
+                        }
                         //各種ボタンの表示制御
                         ButtonsEnableSetting(status);
                     }
@@ -1196,6 +1215,23 @@ namespace NipponPaint.OrderManager
                             {
                                 BorderHgNote.Visible = false;
                             }
+                        }
+                        //容量コードのLabelTextBoxコントロールに設定された値を取得してProductNo_Masterに存在するか確認する
+                        string productNo = HgProductNo.Value.Trim();
+                        // 行取得のSQLを作成
+                        parameters = new List<ParameterItem>()
+                        {
+                            new ParameterItem("ProductNo", productNo),
+                        };
+                        rec = db.Select(Sql.NpMain.ProductNoMaster.GetCountByProductNo(), parameters);
+                        result = int.TryParse(rec.Rows[0]["Product_No_Count"].ToString(), out intResult);
+                        if (result)
+                        {
+                            BorderHgVolumeCode.Visible = 0 < intResult;
+                        }
+                        else
+                        {
+                            BorderHgVolumeCode.Visible = false;
                         }
                         //各種ボタンの表示制御
                         ButtonsEnableSetting(status);
@@ -1280,6 +1316,23 @@ namespace NipponPaint.OrderManager
                             {
                                 BorderHgNote.Visible = false;
                             }
+                        }
+                        //容量コードのLabelTextBoxコントロールに設定された値を取得してProductNo_Masterに存在するか確認する
+                        string productNo = HgProductNo.Value.Trim();
+                        // 行取得のSQLを作成
+                        parameters = new List<ParameterItem>()
+                        {
+                            new ParameterItem("ProductNo", productNo),
+                        };
+                        rec = db.Select(Sql.NpMain.ProductNoMaster.GetCountByProductNo(), parameters);
+                        result = int.TryParse(rec.Rows[0]["Product_No_Count"].ToString(), out intResult);
+                        if (result)
+                        {
+                            BorderHgVolumeCode.Visible = 0 < intResult;
+                        }
+                        else
+                        {
+                            BorderHgVolumeCode.Visible = false;
                         }
                         //各種ボタンの表示制御
                         ButtonsEnableSetting(status);
@@ -1461,7 +1514,7 @@ namespace NipponPaint.OrderManager
                 GvOrderNumber.Columns[cnt].Width = item.Width;
                 GvOrderNumber.Columns[cnt].Visible = item.Visible;
                 GvOrderNumber.Columns[cnt].DefaultCellStyle.Alignment = item.alignment;
-                if (cnt <= 0)
+                if (cnt <= 1)
                 {
                     GvOrderNumber.Columns[cnt].HeaderText = string.Empty;
                 }
@@ -1602,6 +1655,23 @@ namespace NipponPaint.OrderManager
         }
         #endregion
 
+        private void GvOrderNumberFormatting(DataGridView dgv)
+        {
+            if (!dgv.Visible)
+            {
+                return;
+            }
+            //if (!ViewGrid.Contains(dgv.Name))
+            //{
+            //    ViewGrid.Add(dgv.Name);
+            //    return;
+            //}
+            foreach (DataGridViewRow row in dgv.Rows)
+            {
+                row.Cells[COLUMN_STATUS].Style.BackColor = StatusBackColorList[int.Parse(row.Cells[COLUMN_STATUS].Value.ToString())];
+                row.Cells[COLUMN_STATUS_COLOR].Style.BackColor = row.Cells[COLUMN_STATUS].Style.BackColor;
+            }
+        }
         #region 製品コードでDataGridViewの該当行を探す
         /// <summary>
         /// 製品コードでDataGridViewの該当行を探す


### PR DESCRIPTION
・缶タブGridViewのステータス表示(色)
　- FrmMain.cs 112,113行　(ブランクのカラム作成)
　- GridViewSetting.cs  ブランク行の取得
　- GvOrderNumberのフォーマット　1658～1674行
　
・容量コード赤枠表示
　- ProductNoMaster.cs 66～74行　(件数取得)
　- FrmMain.cs 1119～1135行, 1219～1235行, 1320～1336行　(赤枠表示)